### PR TITLE
V1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,10 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.0"
+        "php": "^7.0 || ^8.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
     }
 }

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -43,9 +43,17 @@ class Analytics extends Model\ToArray implements Facade\Analytics, Facade\Export
 
     public function getRequiredParams(): array
     {
-        return [
-            'client_id'
-        ];
+        $return = [];
+
+        // Either client_id OR user_id MUST to be set
+        if (
+            (!isset($this->client_id) || empty($this->client_id))
+            && (!isset($this->user_id) || empty($this->user_id))
+        ) {
+            $return[] = 'client_id';
+        }
+
+        return $return;
     }
 
     public function allowPersonalisedAds(bool $allow)

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -6,6 +6,11 @@ use GuzzleHttp\Client as Guzzle;
 use AlexWestergaard\PhpGa4\Facade;
 use AlexWestergaard\PhpGa4\Model;
 
+/**
+ * Foundation class to collect all information and events to send to Google Analytics \
+ * Make sure to get you Measurement ID and a API Secret
+ * @link https://analytics.google.com/ -> Settings -> Data stream -> API Secrets & Measurement Protocol -> Create
+ */
 class Analytics extends Model\ToArray implements Facade\Analytics, Facade\Export
 {
     const URL_LIVE = 'https://www.google-analytics.com/mp/collect';

--- a/src/Event/RemoveFromCart.php
+++ b/src/Event/RemoveFromCart.php
@@ -15,7 +15,7 @@ class RemoveFromCart extends Model\Event implements Facade\RemoveFromCart
 
     public function getName(): string
     {
-        return 'remove_to_cart';
+        return 'remove_from_cart';
     }
 
     public function getParams(): array

--- a/src/Event/Search.php
+++ b/src/Event/Search.php
@@ -11,7 +11,7 @@ class Search extends Model\Event implements Facade\Search
 
     public function getName(): string
     {
-        return 'search_term';
+        return 'search';
     }
 
     public function getParams(): array

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -106,6 +106,12 @@ class AnalyticsTest extends \PHPUnit\Framework\TestCase
             $params = array_unique(array_merge($event->getParams(), $required));
 
             try {
+                $this->assertEquals(
+                    strtolower(basename($file, '.php')),
+                    strtolower(strtr($event->getName(), ['_' => ''])),
+                    strtolower(basename($file, '.php')) . ' is not equal to ' . strtolower(strtr($event->getName(), ['_' => '']))
+                );
+
                 if (in_array('currency', $params)) {
                     $event->setCurrency($this->prefill['currency']);
                     if (in_array('value', $params)) {


### PR DESCRIPTION
Clean up dependency versioning and add strict test on event name compared to filename, fx "add_to_cart" and "AddToCart(.php)" is similar when removing underscores and lowercase. This should help prevent sending events with the wrong name and that way help prevent weird tagging.