### PR TITLE
Update Exception Handling

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -186,11 +186,10 @@ class Analytics extends Model\ToArray implements Facade\Analytics, Facade\Export
         }
 
         if (GA4Exception::hasStack()) {
-            throw GA4Exception::getStack();
+            throw GA4Exception::getFinalStack();
         }
 
         $this->events = [];
-        GA4Exception::resetStack();
 
         return true;
     }

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -42,7 +42,7 @@ class GA4Exception extends \Exception
      * Add new GA4Exception to stack without further action
      *
      * @param string $message
-     * @param integer $code
+     * @param int $code
      * @return void
      */
     public static function push(string $message, int $code = 0)
@@ -53,7 +53,7 @@ class GA4Exception extends \Exception
     /**
      * Check if the stack has any instances
      *
-     * @return boolean
+     * @return bool
      */
     public static function hasStack()
     {
@@ -63,7 +63,7 @@ class GA4Exception extends \Exception
     /**
      * Return unmodified stack
      *
-     * @return void
+     * @return AlexWestergaard\PhpGa4\GA4Exception|null
      */
     public static function getStack()
     {
@@ -74,7 +74,7 @@ class GA4Exception extends \Exception
      * Returns stack and resets/cleans the stack; this one should be used when throwing \
      * to avoid future try-catch blocks will hit the stack build during current run.
      *
-     * @return void
+     * @return AlexWestergaard\PhpGa4\GA4Exception|null
      */
     public static function getFinalStack()
     {

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -4,7 +4,7 @@ namespace AlexWestergaard\PhpGa4;
 
 class GA4Exception extends \Exception
 {
-    private static GA4Exception $GA4ExceptionStack;
+    private static $GA4ExceptionStack;
 
     public function __construct(string $message = "", int $code = 0)
     {

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -4,8 +4,37 @@ namespace AlexWestergaard\PhpGa4;
 
 class GA4Exception extends \Exception
 {
-    public function __construct(string $message = "", $previous = null)
+    private static ?GA4Exception $GA4ExceptionStack = null;
+
+    public function __construct(string $message = "", int $code = 0)
     {
-        parent::__construct($message, 0, $previous);
+        $previous = isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function add()
+    {
+        self::$GA4ExceptionStack = $this;
+    }
+
+    public static function push(string $message, int $code = 0)
+    {
+        self::$GA4ExceptionStack = new static($message, $code);
+    }
+
+    public static function hasStack()
+    {
+        return isset(self::$GA4ExceptionStack) && self::$GA4ExceptionStack !== null;
+    }
+
+    public static function getStack()
+    {
+        return self::$GA4ExceptionStack;
+    }
+
+    public static function resetStack()
+    {
+        static::$GA4ExceptionStack = null;
     }
 }

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -28,12 +28,12 @@ class GA4Exception extends \Exception
 
     public static function getStack()
     {
-        return isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
+        return isset(self::$GA4ExceptionStack) ? self::$GA4ExceptionStack : null;
     }
 
     public static function getFinalStack()
     {
-        $stack = isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
+        $stack = isset(self::$GA4ExceptionStack) ? self::$GA4ExceptionStack : null;
 
         static::resetStack();
 
@@ -42,6 +42,6 @@ class GA4Exception extends \Exception
 
     public static function resetStack()
     {
-        static::$GA4ExceptionStack = null;
+        self::$GA4ExceptionStack = null;
     }
 }

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -4,6 +4,11 @@ namespace AlexWestergaard\PhpGa4;
 
 class GA4Exception extends \Exception
 {
+    /**
+     * Contains ongoing stack of errors that can be returned as chained exceptions
+     *
+     * @var AlexWestergaard\PhpGa4\GA4Exception
+     */
     private static $GA4ExceptionStack;
 
     public function __construct(string $message = "", int $code = 0)
@@ -11,35 +16,80 @@ class GA4Exception extends \Exception
         parent::__construct($message, $code, static::getStack());
     }
 
+    /**
+     * Add current exception to stack
+     *
+     * @return static
+     */
     public function add()
     {
         self::$GA4ExceptionStack = $this;
+        return $this;
     }
 
+    /**
+     * Clean stack - will not affect current instance
+     *
+     * @return static
+     */
+    public function clean()
+    {
+        static::resetStack();
+        return $this;
+    }
+
+    /**
+     * Add new GA4Exception to stack without further action
+     *
+     * @param string $message
+     * @param integer $code
+     * @return void
+     */
     public static function push(string $message, int $code = 0)
     {
         self::$GA4ExceptionStack = new static($message, $code);
     }
 
+    /**
+     * Check if the stack has any instances
+     *
+     * @return boolean
+     */
     public static function hasStack()
     {
         return static::getStack() !== null;
     }
 
+    /**
+     * Return unmodified stack
+     *
+     * @return void
+     */
     public static function getStack()
     {
-        return isset(self::$GA4ExceptionStack) ? self::$GA4ExceptionStack : null;
+        return isset(self::$GA4ExceptionStack) && self::$GA4ExceptionStack instanceof GA4Exception ? self::$GA4ExceptionStack : null;
     }
 
+    /**
+     * Returns stack and resets/cleans the stack; this one should be used when throwing \
+     * to avoid future try-catch blocks will hit the stack build during current run.
+     *
+     * @return void
+     */
     public static function getFinalStack()
     {
-        $stack = isset(self::$GA4ExceptionStack) ? self::$GA4ExceptionStack : null;
+        $stack = static::getStack();
 
         static::resetStack();
 
         return $stack;
     }
 
+    /**
+     * Resets/cleans the stack
+     *
+     * @return void
+     */
     public static function resetStack()
     {
         self::$GA4ExceptionStack = null;

--- a/src/GA4Exception.php
+++ b/src/GA4Exception.php
@@ -4,13 +4,11 @@ namespace AlexWestergaard\PhpGa4;
 
 class GA4Exception extends \Exception
 {
-    private static ?GA4Exception $GA4ExceptionStack = null;
+    private static GA4Exception $GA4ExceptionStack;
 
     public function __construct(string $message = "", int $code = 0)
     {
-        $previous = isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
-
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, $code, static::getStack());
     }
 
     public function add()
@@ -25,12 +23,21 @@ class GA4Exception extends \Exception
 
     public static function hasStack()
     {
-        return isset(self::$GA4ExceptionStack) && self::$GA4ExceptionStack !== null;
+        return static::getStack() !== null;
     }
 
     public static function getStack()
     {
-        return self::$GA4ExceptionStack;
+        return isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
+    }
+
+    public static function getFinalStack()
+    {
+        $stack = isset(static::$GA4ExceptionStack) ? static::$GA4ExceptionStack : null;
+
+        static::resetStack();
+
+        return $stack;
     }
 
     public static function resetStack()

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -17,24 +17,20 @@ abstract class Event extends ToArray implements Facade\Export
     /**
      * @param GA4Exception $childErrors
      */
-    public function toArray(bool $isParent = false, $childErrors = null): array
+    public function toArray(bool $isParent = false): array
     {
-        if (!($childErrors instanceof GA4Exception) && $childErrors !== null) {
-            throw new GA4Exception("$childErrors is neither NULL of instance of GA4Exception");
-        }
         $return = [];
-        $errorStack = null;
 
         if (!method_exists($this, 'getName')) {
-            $errorStack = new GA4Exception("'self::getName()' does not exist", $errorStack);
+            GA4Exception::push("'self::getName()' does not exist");
         } else {
             $name = $this->getName();
             if (empty($name)) {
-                $errorStack = new GA4Exception("Name '{$name}' can not be empty", $errorStack);
+                GA4Exception::push("Name '{$name}' can not be empty");
             } elseif (strlen($name) > 40) {
-                $errorStack = new GA4Exception("Name '{$name}' can not be longer than 40 characters", $errorStack);
+                GA4Exception::push("Name '{$name}' can not be longer than 40 characters");
             } elseif (preg_match('/[^\w\d\-]/', $name)) {
-                $errorStack = new GA4Exception("Name '{$name}' can only be letters, numbers, underscores and dashes", $errorStack);
+                GA4Exception::push("Name '{$name}' can only be letters, numbers, underscores and dashes");
             } elseif (in_array($name, [
                 'ad_activeview',
                 'ad_click',
@@ -59,21 +55,20 @@ abstract class Event extends ToArray implements Facade\Export
                 'session_start',
                 'user_engagement',
             ])) {
-                $errorStack = new GA4Exception("Name '{$name}' is reserved", $errorStack);
+                GA4Exception::push("Name '{$name}' is reserved");
             } else {
                 $return['name'] = $name;
             }
         }
 
-        $catch = parent::toArray(true, $errorStack);
-        $errorStack = $catch['error'];
+        $parent = parent::toArray(true);
 
-        if (is_array($catch['data']) && !empty($catch['data'])) {
-            $return['params'] = $catch['data'];
+        if (!$isParent && GA4Exception::hasStack()) {
+            throw GA4Exception::getStack();
         }
 
-        if ($errorStack instanceof GA4Exception) {
-            throw $errorStack;
+        if (!empty($parent)) {
+            $return['params'] = $parent;
         }
 
         return $return;

--- a/src/Model/Event.php
+++ b/src/Model/Event.php
@@ -64,7 +64,7 @@ abstract class Event extends ToArray implements Facade\Export
         $parent = parent::toArray(true);
 
         if (!$isParent && GA4Exception::hasStack()) {
-            throw GA4Exception::getStack();
+            throw GA4Exception::getFinalStack();
         }
 
         if (!empty($parent)) {

--- a/src/Model/ToArray.php
+++ b/src/Model/ToArray.php
@@ -14,59 +14,45 @@ abstract class ToArray implements Facade\Export
     /**
      * @param GA4Exception $childErrors
      */
-    public function toArray(bool $isParent = false, $childErrors = null): array
+    public function toArray(bool $isParent = false): array
     {
-        if (!($childErrors instanceof GA4Exception) && $childErrors !== null) {
-            throw new GA4Exception("$childErrors is neither NULL of instance of GA4Exception");
-        }
-
         $return = [];
-        $errorStack = null;
-
-        if ($isParent !== null) {
-            $errorStack = $childErrors;
-        }
 
         $required = $this->getRequiredParams();
         $params = array_unique(array_merge($this->getParams(), $required));
 
         foreach ($params as $param) {
             if (!property_exists($this, $param)) {
-                $errorStack = new GA4Exception("Param '{$param}' is not defined", $errorStack);
+                GA4Exception::push("Param '{$param}' is not defined");
                 continue;
             } elseif (!isset($this->{$param})) {
                 if (in_array($param, $required)) {
-                    $errorStack = new GA4Exception("Param '{$param}' is required but not set", $errorStack);
+                    GA4Exception::push("Param '{$param}' is required but not set");
                 }
                 continue;
             } elseif (empty($this->{$param}) && (is_array($this->{$param}) || strval($this->{$param}) !== '0')) {
                 if (in_array($param, $required)) {
-                    $errorStack = new GA4Exception("Param '{$param}' is required but empty", $errorStack);
+                    GA4Exception::push("Param '{$param}' is required but empty");
                 }
                 continue;
             }
 
             if (strlen($param) > 40) {
-                $errorStack = new GA4Exception("Param '{$param}' is too long, maximum is 40 characters", $errorStack);
+                GA4Exception::push("Param '{$param}' is too long, maximum is 40 characters");
             }
 
             $value = $this->{$param};
 
             // Array values be handled and validated within setter, fx addItem/setItem
             if (!is_array($value) && mb_strlen($value) > 100) {
-                $errorStack = new GA4Exception("Value '{$value}' is too long, maximum is 100 characters", $errorStack);
+                GA4Exception::push("Value '{$value}' is too long, maximum is 100 characters");
             }
 
             $return[$param] = $value;
         }
 
-        if ($isParent) {
-            return [
-                'data' => $return,
-                'error' => $errorStack
-            ];
-        } elseif ($errorStack instanceof GA4Exception) {
-            throw $errorStack;
+        if (!$isParent && GA4Exception::hasStack()) {
+            throw GA4Exception::getStack();
         }
 
         return $return;

--- a/src/Model/ToArray.php
+++ b/src/Model/ToArray.php
@@ -52,7 +52,7 @@ abstract class ToArray implements Facade\Export
         }
 
         if (!$isParent && GA4Exception::hasStack()) {
-            throw GA4Exception::getStack();
+            throw GA4Exception::getFinalStack();
         }
 
         return $return;

--- a/test/AnalyticsTest.php
+++ b/test/AnalyticsTest.php
@@ -192,6 +192,10 @@ class AnalyticsTest extends \PHPUnit\Framework\TestCase
                 $event->setAchievementId('achievement_buy_5_items');
             }
 
+            if (in_array('group_id', $params)) {
+                $event->setGroupId('999');
+            }
+
             $this->assertTrue(is_array($event->toArray()), $eventName);
 
             $this->analytics->addEvent($event);


### PR DESCRIPTION
Internalize `GA4Exception`'s when iterating data without wanting to throw midways.